### PR TITLE
Undo after promotion + capture restores the captured pieces

### DIFF
--- a/draughts.js
+++ b/draughts.js
@@ -882,6 +882,9 @@ var Draughts = function (fen) {
         position = setCharAt(position, convertNumber(move.captures[i], 'internal'), move.piecesCaptured[i])
       }
     } else if (move.flags === 'p') {
+      for (var i = 0; i < move.captures.length; i += 1) {
+        position = setCharAt(position, convertNumber(move.captures[i], 'internal'), move.piecesCaptured[i])
+      }
       position = setCharAt(position, convertNumber(move.from, 'internal'), move.piece.toLowerCase())
     }
     return move


### PR DESCRIPTION
when undoing after a promotion and pieces have been taken, the taken pieces were not displayed