### PR TITLE
Fix for passing a square position to moves

### DIFF
--- a/draughts.js
+++ b/draughts.js
@@ -644,7 +644,7 @@ var Draughts = function (fen) {
     var moves = []
 
     if (square) {
-      moves = getLegalMoves(square.square)
+      moves = getLegalMoves(square)
     } else {
       var tempCaptures = getCaptures()
       // TODO change to be applicable to array


### PR DESCRIPTION
Code is looking for square.square, not sure what that's supposed to be, getting rid of the .square allows passing a position ie moves("31") and returns a list of moves from that location.